### PR TITLE
Add missing OutsideClickWatcher reference in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 // Atoms
+export { default as OutsideClickWatcher } from './src/atoms/OutsideClickWatcher';
 export { default as PageOverlay } from './src/atoms/PageOverlay';
 export { default as Card } from './src/atoms/card/Card';
 export { default as CardBody } from './src/atoms/card/CardBody';

--- a/src/atoms/OutsideClickWatcher/outsideclickwatcher.tests.js
+++ b/src/atoms/OutsideClickWatcher/outsideclickwatcher.tests.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import OutsideClickWatcher from '.';
+import { OutsideClickWatcher } from '../../..';
 
 const test = (onClick = () => {}) => {
     return mount(


### PR DESCRIPTION
* Adds the missing reference
* Updates the test to refer to index.js in order to retrieve the component